### PR TITLE
Pull Request Review - General - allow use of arbitrary minor version of ASP.NET for build

### DIFF
--- a/MKCards/MKCards.Client/MKCards.Client.csproj
+++ b/MKCards/MKCards.Client/MKCards.Client.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor.Bootstrap" Version="3.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.*" />
   </ItemGroup>
 
   <Import Project="..\MKCards.Common\MKCards.Common.projitems" Label="Shared" />

--- a/MKCards/MKCards.Server/MKCards.Server.csproj
+++ b/MKCards/MKCards.Server/MKCards.Server.csproj
@@ -9,12 +9,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\MKCards.Client\MKCards.Client.csproj" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8" />
-		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.*" />
+		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.*" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This should make it possible to build to project with any ASP.NET version 8.0.x.
Previously the version was fixed to 8.0.8.